### PR TITLE
Fix/improve cacert detection

### DIFF
--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -20,9 +20,11 @@ kubectl create namespace "$CS_NAMESPACE" || true
 # - The cloud should be called openstack
 # - We will detect a cacert in there and pass it to the helper chart
 if ! test -r "$CLOUDS_YAML"; then echo "clouds.yaml $CLOUDS_YAML not readable"; exit 2; fi
-CA=$(grep -A12 "^  *$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | sed 's/^ *cacert: //')
+CA=$(grep -A12 "^  *$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | head -n1 | sed 's/^ *cacert: //')
 OS_CACERT=${OS_CACERT:-$CA}
 if test -n "$OS_CACERT"; then
+	echo "Found CA cert file configured to be $OS_CACERT"
+	if test ! -r "$OS_CACERT"; then echo "... but could not access it. FATAL."; exit 3; fi
 	# Call the helm helper chart now
 	helm upgrade -i openstack-secrets -n "$CS_NAMESPACE" --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f $CLOUDS_YAML --set cacert="$(cat $OS_CACERT)"
 else

--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -20,7 +20,7 @@ kubectl create namespace "$CS_NAMESPACE" || true
 # - The cloud should be called openstack
 # - We will detect a cacert in there and pass it to the helper chart
 if ! test -r "$CLOUDS_YAML"; then echo "clouds.yaml $CLOUDS_YAML not readable"; exit 2; fi
-CA=$(grep -A11 "^  $OS_CLOUD:" $CLOUDS_YAML | grep 'cacert:' | sed 's/^ *cacert: //')
+CA=$(grep -A12 "^  *$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | sed 's/^ *cacert: //')
 OS_CACERT=${OS_CACERT:-$CA}
 if test -n "$OS_CACERT"; then
 	# Call the helm helper chart now

--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -20,7 +20,7 @@ kubectl create namespace "$CS_NAMESPACE" || true
 # - The cloud should be called openstack
 # - We will detect a cacert in there and pass it to the helper chart
 if ! test -r "$CLOUDS_YAML"; then echo "clouds.yaml $CLOUDS_YAML not readable"; exit 2; fi
-CA=$(grep -A12 "^  *$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | head -n1 | sed 's/^ *cacert: //')
+CA=$(grep -A12 "^\s\s*$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | head -n1 | sed 's/^ *cacert: //')
 OS_CACERT=${OS_CACERT:-$CA}
 if test -n "$OS_CACERT"; then
 	echo "Found CA cert file configured to be $OS_CACERT"

--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -20,7 +20,7 @@ kubectl create namespace "$CS_NAMESPACE" || true
 # - The cloud should be called openstack
 # - We will detect a cacert in there and pass it to the helper chart
 if ! test -r "$CLOUDS_YAML"; then echo "clouds.yaml $CLOUDS_YAML not readable"; exit 2; fi
-CA=$(grep -A12 "^\s\s*$OS_CLOUD: *$" $CLOUDS_YAML | grep 'cacert:' | head -n1 | sed 's/^ *cacert: //')
+CA=$(grep -A12 "^\s\s*$OS_CLOUD:\s*\$" $CLOUDS_YAML | grep 'cacert:' | head -n1 | sed 's/^ *cacert: //')
 OS_CACERT=${OS_CACERT:-$CA}
 if test -n "$OS_CACERT"; then
 	echo "Found CA cert file configured to be $OS_CACERT"


### PR DESCRIPTION
This should address issue #1.

No, it's not perfect -- we'd need to parse yaml from shell to get there.

Maybe we need to re-add yq to the list of requirements to do this cleanly.
(The trouble with jq and yq is that there are two somewhat incompatible variants, sigh. Another option would be a few lines of python code, requiring python3-PyYAML or so.)
