### PR TITLE
Construct a compliant clouds.yaml for the help chart.

### DIFF
--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -11,6 +11,10 @@ else
 fi
 # Read settings -- make sure you can trust it
 source "$SET"
+# Read helper
+THISDIR=$(dirname 0)
+source "$THISDIR/yaml_parse.sh"
+
 # Create namespace
 test -n "$CS_NAMESPACE"
 kubectl create namespace "$CS_NAMESPACE" || true
@@ -20,18 +24,37 @@ kubectl create namespace "$CS_NAMESPACE" || true
 # - The cloud should be called openstack
 # - We will detect a cacert in there and pass it to the helper chart
 if ! test -r "$CLOUDS_YAML"; then echo "clouds.yaml $CLOUDS_YAML not readable"; exit 2; fi
-CA=$(grep -A12 "^\s\s*$OS_CLOUD:\s*\$" $CLOUDS_YAML | grep '^\s*cacert:' | head -n1 | tr -d '"' | sed 's/^\s*cacert: *//')
-# This would be the safe way using yq:
-# CA=$(yq -y < $CLOUDS_YAML '.clouds."'$OS_CLOUD'".cacert' | head -n1); if test "$CA" = "null"; then unset CA; fi
+CA=$(RMVTREE=1 extract_yaml clouds.$OS_CLOUD.cacert <$CLOUDS_YAML | sed 's/^\s*cacert: //' || true)
 OS_CACERT="${OS_CACERT:-$CA}"
+# Extract auth parts from secure.yaml if existent, assume same indentation
+SEC_YAML="${CLOUDS_YAML%clouds.yaml}secure.yaml"
+if test -r "$SEC_YAML"; then SECRETS=$(RMVTREE=1 RMVCOMMENT=1 extract_yaml clouds.$OS_CLOUD.auth < $SEC_YAML || true); fi
+# Construct a clouds.yaml (mode 0600):
+# - Only extracting one cloud addressed by $OS_CLOUD
+# - By merging secrets in from secure.yaml
+# - By renaming it to openstack (current CS limitation)
+# - By removing cacert setting
+# Store it securely in ~/tmp/clouds-$OS_CLOUD.yaml
+OLD_UMASK=$(umask)
+umask 0177
+APPEND="$SECRETS" RMVCOMMENT=1 REMOVE=cacert extract_yaml clouds.$OS_CLOUD < $CLOUDS_YAML | sed "s/^\\(\\s*\\)\\($OS_CLOUD\\):/\\1openstack:/" > ~/tmp/clouds-$OS_CLOUD.yaml
+umask $OLD_UMASK
 # FIXME: We will provide more settings in cluster-settings.env later, hardcode it for now
 #if test "$CS_CCMLB=octavia-ovn"; then OCTOVN="--set octavia_ovn=true"; else unset OCTOVN; fi
 OCTOVN="--set octavia_ovn=true"
 if test -n "$OS_CACERT"; then
-	echo "Found CA cert file configured to be $OS_CACERT"
-	if test ! -r "$OS_CACERT"; then echo "... but could not access it. FATAL."; exit 3; fi
+	echo "Found CA cert file configured to be \"$OS_CACERT\""
+	OS_CACERT="$(ls ${OS_CACERT/\~/$HOME})"
+	# This will error out as needed
+	# Extract last cert if things get too long (heuristic!)
+	if test $(wc -l < $OS_CACERT) -gt 200; then
+		LASTLN=$(tac $OS_CACERT | grep -n '^-----BEGIN CERTIFICATE-----$' | head -n1 | sed 's/^\([0-9]*\):.*/\1/')
+		CACERT="$(tac $OS_CACERT | head -n $LN | tac)"
+	else
+		CACERT="$(cat $OS_CACERT)"
+	fi
 	# Call the helm helper chart now
-	helm upgrade -i openstack-secrets -n "$CS_NAMESPACE" --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f $CLOUDS_YAML --set cacert="$(cat $OS_CACERT)" $OCTOVN
+	helm upgrade -i openstack-secrets -n "$CS_NAMESPACE" --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f ~/tmp/clouds-$OS_CLOUD.yaml --set cacert="$CACERT" $OCTOVN
 else
-	helm upgrade -i openstack-secrets -n "$CS_NAMESPACE" --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f $CLOUDS_YAML $OCTOVN
+	helm upgrade -i openstack-secrets -n "$CS_NAMESPACE" --create-namespace https://github.com/SovereignCloudStack/openstack-csp-helper/releases/latest/download/openstack-csp-helper.tgz -f ~/tmp/clouds-$OS_CLOUD.yaml $OCTOVN
 fi

--- a/yaml_parse.sh
+++ b/yaml_parse.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# YAML parser helper
+# We do some (incomplete) YAML parsing in bash as helper to 04-cloud-secret.sh
+# to extract and construct a conforming clouds.yaml with exactly one
+# openstack entry.
+# This is SLOW by walking a file line by line, using several grep calls per line,
+# which is a fork.
+# Could be optimized by doing the simple things in bash, but this is not urgent.
+# 
+# (c) Kurt Garloff <s7n@garloff.de>, 5/2025
+# SPDX-License-Identifier: CC-BY-SA-4.0
+#
+# Helper: Parse YAML (recursive)
+#
+# We take two parameters
+# $1: The indentation whitespace
+# $2: "1" => We want more indentation
+# $3-: The keywords
+#
+# Environment to pass special functions
+# $RMVTREE nonempty: Do not output yaml path leading to this section
+# $INSERT and $APPEND is text injected in the outputted block (at beginning and end resp.)
+# $REMOVE is a tag to filter out
+# $RMVCOMMTENT nonempty: Strip comments
+#
+# Return value: 0 if we found (and output) a block, 1 otherwise
+extract_yaml_rec()
+{
+	#echo "DEBUG: Called extract_yaml_rec $@" 1>&2
+	local previndent="$1"
+	local more="$2"
+	#global LNNO
+	shift 2
+	if test -n "$1"; then NOTFOUND=1; fi
+	while IFS="" read line; do
+		let LNNO+=1
+		# Ignore empty lines
+		if echo "$line" | grep '^\s*$' >/dev/null 2>&1; then continue; fi
+		# First line of new block: We need more indentation ...
+		if test "$more" = "1"; then
+		       if ! echo "$line" | grep "^$previndent\s" >/dev/null 2>&1; then return; fi
+		       more=$(echo "$line" | sed "s/^$previndent\\(\s*\\)[^\s].*\$/\\1/")
+		       #echo "$previndent$more# $LNNO: New indent level"
+		fi
+		# Detect less indentation than wanted, return
+		if ! echo "$line" | grep "^$previndent$more" >/dev/null 2>&1; then return; fi
+		# Strip comments if requested
+		if test -n "$RMVCOMMENT" && echo "$line" | grep '^\s*#' >/dev/null 2>&1; then continue; fi
+		# OK, we we have at least the indentation level needed
+		# 3 cases:
+		# (a) We are prior to finding the right block, continue searching
+		# (b1) Found it, no more nesting needed, output till the end
+		# (b2) Found it, recurse into next keyword
+		# (c) We idenitfy the end by finding a different keyword
+		#
+		# Case b1: No more keywords to look for, we found the previous ones if we
+		# got here, just output until the less indentation clause above indicates the end
+		if test -z "$1"; then
+			#echo "$previndent$more# $LNNO: Outputing block"
+			if test -z "$REMOVE" || ! echo "$line" | grep "^$previndent$more$REMOVE:" >/dev/null 2>&1; then
+				echo "$line"
+			fi
+			continue
+		fi
+		# b2: Search for the keyword
+		if echo "$line" | grep "^$previndent$more$1:" >/dev/null 2>&1; then
+			#echo "$previndent$more# $LNNO: Found keyword $1"
+			# Output tree unless we suppress it
+			if test -z "$RMVTREE"; then
+				echo "$line"
+			else
+				# At the leaf, we may hold a value
+				if test -z "$2"; then
+					echo "$line" | grep --color=never "^$previndent$more$1: [^\\s]" 2>/dev/null
+				fi
+			fi
+			shift
+			# TODO: Reformat INSERT to match
+			if test -z "$1"; then
+				NOTFOUND=0
+				if test -n "$INSERT"; then echo "$INSERT"; fi
+			fi
+			extract_yaml_rec "$previndent$more" "1" "$@"
+			# TODO: Reformat APPEND to match
+			if test -z "$1" -a -n "$APPEND"; then echo "$APPEND"; fi
+			# A return here would allows for only one block of a kind
+			return $NOTFOUND
+			# Otherwise we would have needed to save "$@" adn restore it here
+		fi
+		# a: OK, just continue to search (without the return above, this is also c)
+	done
+	return $NOTFOUND
+}
+
+# Helper: extract_yaml
+# $1: The tag to search for and output (separated by dots)
+extract_yaml()
+{
+	LNNO=0
+	SRCH=($(echo "$1" | sed 's/\./ /g'))
+	extract_yaml_rec "" "" "${SRCH[@]}"
+}
+


### PR DESCRIPTION
OK, so we now have a basic YAML parser and extractor in bash (slow). This avoids the need for python or yq (or shyaml).

Here's what we do now to avoid failing clouds.yaml construction:
- Detect the need for a cacert file
  * And extract only the last if it's huge.
  * But remove it from the constructed clouds.yaml.
- Merge the auth section from a secure.yaml file
- Extract only one cloud for the helm helper and rename it to openstack
- Store it (0600) to ~/tmp/clouds-$OS_CLOUD.yaml