### PR TITLE
Graft clouds.yaml correctly even if we need to insert in the middle.

### DIFF
--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -62,7 +62,7 @@ fi
 echo "# Generating ~/tmp/clouds-$OS_CLOUD.yaml ..."
 OLD_UMASK=$(umask)
 umask 0177
-APPEND="$SECRETS" RMVCOMMENT=1 REMOVE=cacert extract_yaml clouds.$OS_CLOUD < $CLOUDS_YAML | sed "s/^\\(\\s*\\)\\($OS_CLOUD\\):/\\1openstack:/" > ~/tmp/clouds-$OS_CLOUD.yaml
+INJECTSUB="$SECRETS" INJECTSUBKWD="auth" RMVCOMMENT=1 REMOVE=cacert extract_yaml clouds.$OS_CLOUD < $CLOUDS_YAML | sed "s/^\\(\\s*\\)\\($OS_CLOUD\\):/\\1openstack:/" > ~/tmp/clouds-$OS_CLOUD.yaml
 umask $OLD_UMASK
 # FIXME: We will provide more settings in cluster-settings.env later, hardcode it for now
 #if test "$CS_CCMLB=octavia-ovn"; then OCTOVN="--set octavia_ovn=true"; else unset OCTOVN; fi

--- a/yaml_parse.sh
+++ b/yaml_parse.sh
@@ -51,6 +51,7 @@ islinecomment()
 # Environment to pass special functions
 # $RMVTREE nonempty: Do not output yaml path leading to this section
 # $INSERT and $APPEND is text injected in the outputted block (at beginning and end resp.)
+# $INJECTSUB and $INJECTSUBKWD: inject text $INJECTSUB after the subsection $INJECTSUBKWD has been found
 # $REMOVE is a tag to filter out
 # $RMVCOMMTENT nonempty: Strip comments
 #
@@ -94,6 +95,10 @@ extract_yaml_rec()
 			#if test -z "$REMOVE" || ! echo "$line" | grep -q "^$previndent$more$REMOVE:"; then
 			if test -z "$REMOVE" || ! startswith "$previndent$more$REMOVE:" "$line"; then
 				echo "$line"
+			fi
+			if test -n "$INJECTSUB" -a -n "$INJECTSUBKWD" && startswith "$previndent$more$INJECTSUBKWD:" "$line"; then
+				echo "$INJECTSUB"
+				unset INJECTSUB
 			fi
 			continue
 		fi


### PR DESCRIPTION
We were using APPEND to attach project_id and user and password, assuming the auth section is at the end of the clouds entry. There is no guarantee for that to be the case though.
Make the injection more robust, by explicitly allowing to specify a subentry auth and inject it there.