### PR TITLE
Feat/add workload lb fixup ovn

### DIFF
--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -13,7 +13,7 @@ fi
 # Read settings -- make sure you can trust it
 source "$SET"
 # Read helper
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 source "$THISDIR/_yaml_parse.sh"
 
 # Create namespace

--- a/04-cloud-secret.sh
+++ b/04-cloud-secret.sh
@@ -44,6 +44,7 @@ fi
 RAW_CLOUD=$(extract_yaml clouds.$OS_CLOUD <$CLOUDS_YAML)
 if ! echo "$RAW_CLOUD" | grep -q '^\s*project_id:' && echo "$RAW_CLOUD" | grep -q '^\s*project_name:'; then
 	# Need openstack CLI for this
+	echo "# Using openstack tools to determine project_id ..."
 	PROJECT_NAME=$(echo "$RAW_CLOUD" | grep '^\s*project_name:' | sed 's/^\s*project_name: //')
 	PROJECT_ID=$(openstack project show $PROJECT_NAME -c id -f value | tr -d '\r')
 	INDENT=$(echo "$RAW_CLOUD" | grep '^\s*project_name:' | sed 's/^\(\s*\)project_name:.*$/\1/')
@@ -53,6 +54,7 @@ fi
 # We need a region_name, add it in
 if ! echo "$RAW_CLOUD" | grep -q '^\s*region_name:'; then
 	# Need openstack CLI for this
+	echo "# Using openstack tools to determine region_name ..."
 	REGION=$(openstack region list -c Region -f value | head -n1 | tr -d '\r')
 	INDENT=$(echo "$RAW_CLOUD" | grep '^\s*auth:' | sed 's/^\(\s*\)auth:.*$/\1/')
 	export INSERT="${INDENT}region_name: $REGION"

--- a/07-cluster-secret.sh
+++ b/07-cluster-secret.sh
@@ -14,7 +14,7 @@ fi
 # Read settings -- make sure you can trust it
 source "$SET"
 # Read helper
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 source "$THISDIR/_yaml_parse.sh"
 
 # Create namespace

--- a/20-install-gateway-api-crd.sh
+++ b/20-install-gateway-api-crd.sh
@@ -2,7 +2,7 @@
 # (c) Kurt Garloff <s7n@garloff.de>, 5/2025
 # SPDX-License-Identifier: CC-BY-SA-4.0
 set -e
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 # We need settings
 unset KUBECONFIG
 if test -n "$1"; then

--- a/21-deploy-kube-dashboard.sh
+++ b/21-deploy-kube-dashboard.sh
@@ -2,7 +2,7 @@
 # (c) Kurt Garloff <s7n@garloff.de>, 5/2025
 # SPDX-License-Identifier: CC-BY-SA-4.0
 set -e
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 # We need settings
 unset KUBECONFIG
 if test -n "$1"; then

--- a/50-remove-kube-dashboard.sh
+++ b/50-remove-kube-dashboard.sh
@@ -2,7 +2,7 @@
 # (c) Kurt Garloff <s7n@garloff.de>, 5/2025
 # SPDX-License-Identifier: CC-BY-SA-4.0
 set -e
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 # We need settings
 unset KUBECONFIG
 if test -n "$1"; then

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ The fix has been accepted upstream and will be in the cinder-csi-2.33 driver.
 Note that the workaround is also not required any longer for the new
 `clouds.yaml` configuration style of scs2 series cluster stacks.
 
+### OVN loadbalancer fixup
+The new way on configuring OCCM's credentials for the cloud consist
+of setting `use-clouds = true` in the `[Global]` swection of `cloud.conf`.
+The `cloud.conf` is auto-generated, and I have not yet found a way to
+tweak the process. The script `_11-fixup-ovn-lb.sh` does change the
+`ccm-cloud-confit` secret to enable the ovn LB provider and restarts
+the OCCM.
+
 ### Testing and utilities
 * `20-install-gateway-api-crd.sh`: Install gateway API CRDs.
   You will need to reinstall Cilium with the right settings to get

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The new way on configuring OCCM's credentials for the cloud consist
 of setting `use-clouds = true` in the `[Global]` swection of `cloud.conf`.
 The `cloud.conf` is auto-generated, and I have not yet found a way to
 tweak the process. The script `_11-fixup-ovn-lb.sh` does change the
-`ccm-cloud-confit` secret to enable the ovn LB provider and restarts
+`ccm-cloud-config` secret to enable the ovn LB provider and restarts
 the OCCM.
 
 ### Testing and utilities

--- a/_04-old-cloud-secret.sh
+++ b/_04-old-cloud-secret.sh
@@ -13,7 +13,7 @@ fi
 # Read settings -- make sure you can trust it
 source "$SET"
 # Read helper
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 source "$THISDIR/_yaml_parse.sh"
 
 # Create namespace

--- a/_10-old-fixup-cinder.sh
+++ b/_10-old-fixup-cinder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# 09-fixup-cinder.sh: Patch Cinder-CSI config path from /etc/kubernetes/
+# _10-fixup-cinder.sh: Patch Cinder-CSI config path from /etc/kubernetes/
 # de
 #  to /etc/config/, so the reference ca-file=/etc/config/cacert in the
 #  file cloud.conf points to an existing place again.
@@ -10,7 +10,7 @@
 # (c) Kurt Garloff <s7n@garloff.de>, 5/2025
 # SPDX-License-Identifier: CC-BY-SA-4.0
 set -e
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 # We need settings
 #unset KUBECONFIG
 if test -n "$1"; then

--- a/_11-fixup-ovn-lb.sh
+++ b/_11-fixup-ovn-lb.sh
@@ -33,7 +33,7 @@ NCCONF=$(LB=0; while read line; do
 		if test "${line:0:1}" = "[" -a $LB = 1; then LB=0; echo "$line"; continue; fi
 		if test "$line" = "[LoadBalancer]"; then LB=1; continue; fi
 		# If we got here, we are in the Loadbalancer section
-		if test -z "$line"; then echo -e "enabled = true\nlb-provider = ovn\nlb-method = SOURCE_IP_PORT\ncreate_monitor = true\n"; fi
+		if test -z "$line"; then echo -e "enabled = true\nlb-provider = ovn\nlb-method = SOURCE_IP_PORT\ncreate-monitor = true\n"; fi
 		# Don't output anything else here
 	done < <(echo "$CCONF" | base64 -d) | base64 -w0)
 NCONF_SECRET=$(while IFS="" read line; do

--- a/_11-fixup-ovn-lb.sh
+++ b/_11-fixup-ovn-lb.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# 11-fixup-ovn-lb.sh: Patch ccm-cloud-config secret to use ovn LB provider
+#
+# This is required to make the OCCM create octavia-ovn LBs for workloads.
+# This is a temporary solution. We should have a proper setting in cluster-settings.env
+# that gets passed down and is being consumed when the creaton of ccm-cloud-config
+# happens.
+#
+# (c) Kurt Garloff <s7n@garloff.de>, 7/2025
+# SPDX-License-Identifier: CC-BY-SA-4.0
+set -e
+THISDIR=$(dirname 0)
+# We need settings
+#unset KUBECONFIG
+if test -n "$1"; then
+	SET="$1"
+else
+	if test -e cluster-settings.env; then SET=cluster-settings.env;
+	else echo "You need to pass a cluster-settings.env file as parameter"; exit 1
+	fi
+fi
+# Read settings -- make sure you can trust it
+source "$SET"
+# Do this on the workload cluster, ensure we have a config
+#clusterctl get kubeconfig -n $CS_NAMESPACE $CL_NAME > ~/.kube/$CS_NAMESPACE.$CL_NAME
+export KUBECONFIG=~/.kube/$CS_NAMESPACE.$CL_NAME
+CCONF_SECRET=$(kubectl get -n kube-system secrets ccm-cloud-config -o yaml)
+CCONF=$(echo "$CCONF_SECRET" | grep '^\s*cloud.conf:' | sed 's/^\s*cloud.conf: //')
+NCCONF=$(LB=0; while read line; do
+		if test $LB = 0; then echo "$line"; fi
+		if test "$line" != "[LoadBalancer]" -a $LB = 0; then continue; fi
+		if test "${line:0:1}" = "[" -a $LB = 1; then LB=0; echo "$line"; continue; fi
+		if test "$line" = "[LoadBalancer]"; then LB=1; continue; fi
+		# If we got here, we are in the Loadbalancer section
+		if test -z "$line"; then echo -e "enabled = true\nlb-provider = ovn\nlb-method = SOURCE_IP_PORT\ncreate_monitor = true\n"; fi
+		# Don't output anything else here
+	done < <(echo "$CCONF" | base64 -d) | base64 -w0)
+NCONF_SECRET=$(while read line; do
+		if echo "$line" | grep '^\s*cloud.conf' >/dev/null 2>&1; then
+			echo "$line" | sed "s/cloud.conf: .*\$/cloud.conf: $NCCONF/"
+		else
+			echo "$line"
+		fi
+	done < <(echo "$CCONF_SECRET"))
+echo "$NCONF_SECRET" | kubectl apply -f
+kubectl rollout restart -n kube-system daemonset openstack-cloud-controller-manager

--- a/_11-fixup-ovn-lb.sh
+++ b/_11-fixup-ovn-lb.sh
@@ -10,7 +10,7 @@
 # (c) Kurt Garloff <s7n@garloff.de>, 7/2025
 # SPDX-License-Identifier: CC-BY-SA-4.0
 set -e
-THISDIR=$(dirname 0)
+THISDIR=$(dirname $0)
 # We need settings
 #unset KUBECONFIG
 if test -n "$1"; then


### PR DESCRIPTION
I'm sure there is a more elegant way than patching the `ccm-cloud-config` secret in the cluster that got autocreated to say `use-clouds = true` in `[Global]` by somehow passing something to whomever does the autocreation.
The way I have found to make things work is to patch the secret and restart OCCM.
This should be replaced by a more elegant solution, but for now is what makes it possible to handle the workaround.